### PR TITLE
fix typo

### DIFF
--- a/bin/systemd/switchmap-ng-poller
+++ b/bin/systemd/switchmap-ng-poller
@@ -116,7 +116,7 @@ class PollingAgent(Agent):
             pollertime = int(time.time()) - ts_poller_start
             log_message = (
                 'Completed device polling sequence. {}s loop duration, {}s poller uptime'
-                ''.format(looptime, pollertime)
+                ''.format(looptime, pollertime))
             log.log2info(1125, log_message)
 
             # Sleep for "delay" seconds


### PR DESCRIPTION
foolishly thought I'd checked before the last PR. Properly tested now. My apologies.

Output now:
```
2023-02-10 12:35:29,982 - switchmap_file - INFO - [dthor] (1055S): Completed search file creation.
2023-02-10 12:35:29,983 - switchmap_file - INFO - [dthor] (1125S): Completed device polling sequence. 202s loop duration, 202s poller uptime
```

