### PR TITLE
test_macport.py runs without faliures consistently

### DIFF
--- a/tests/switchmap_/server/db/table/test_macport.py
+++ b/tests/switchmap_/server/db/table/test_macport.py
@@ -100,13 +100,16 @@ class TestDbTableMacPort(unittest.TestCase):
     def test_idx_exists(self):
         """Testing function idx_exists."""
         # Create record
-        row = _row()
+        while True:
+            row = _row()
+            if not testimport.exists(row.idx_l1interface, row.idx_mac):
+                break
 
-        # Test before insertion of an initial row
+        # Test before insertion
         nonexistent = testimport.exists(row.idx_l1interface, row.idx_mac)
         self.assertFalse(nonexistent)
 
-        # Test after insertion of an initial row
+        # Insert
         testimport.insert_row(row)
         preliminary_result = testimport.exists(row.idx_l1interface, row.idx_mac)
         self.assertTrue(preliminary_result)
@@ -120,13 +123,16 @@ class TestDbTableMacPort(unittest.TestCase):
     def test_exists(self):
         """Testing function exists."""
         # Create record
-        row = _row()
+        while True:
+            row = _row()
+            if not testimport.exists(row.idx_l1interface, row.idx_mac):
+                break
 
-        # Test before insertion of an initial row
+        # Test before insertion
         result = testimport.exists(row.idx_l1interface, row.idx_mac)
         self.assertFalse(result)
 
-        # Test after insertion of an initial row
+        # Insert
         testimport.insert_row(row)
         result = testimport.exists(row.idx_l1interface, row.idx_mac)
         self.assertTrue(result)
@@ -200,7 +206,7 @@ class TestDbTableMacPort(unittest.TestCase):
                 self.assertFalse(result)
                 break
 
-        # Test after insertion of an initial row
+        # Test after insertion
         testimport.insert_row(row)
         result = testimport.exists(row.idx_l1interface, row.idx_mac)
         self.assertTrue(result)
@@ -208,12 +214,9 @@ class TestDbTableMacPort(unittest.TestCase):
 
     def test_update_row(self):
         """Testing function update_row."""
-        # Find a row combination that does not exist
+        # Find a row combination that does exist
         while True:
-            # Create record
             row = _row()
-
-            # Test before insertion of an initial row
             result = testimport.exists(row.idx_l1interface, row.idx_mac)
             if bool(result) is True:
                 self.assertTrue(result)


### PR DESCRIPTION
### **Pull Request Template**

**What kind of change does this PR introduce?**  
Bugfix  

**Issue Number:**  
Fixes #284  

**Snapshots/Videos:**  
### Before: 
[Screencast from 2025-01-29 14-52-26.webm](https://github.com/user-attachments/assets/fc86ea46-64ad-4afe-a240-ce15aade7a8c)

### After: 
[Screencast from 2025-01-29 14-53-17.webm](https://github.com/user-attachments/assets/a18b541c-1143-4f85-8291-33061d68b984)



**If relevant, did you update the documentation?**  
N/A  

---

### **Summary**

This PR resolves the intermittent failures in `test_macport.py::TestDbTableMacPort::test_idx_exists`. The issue was caused by datetime values in the database, which led to inconsistencies during test execution.  

---

### **Does this PR introduce a breaking change?**  
No  

---

### **Checklist**

#### **CodeRabbit AI Review**  
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI.  
- [x] I have implemented or provided justification for each non-critical suggestion.  
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented.  

#### **Test Coverage**  
- [x] I have written tests for all new changes/features.  
- [x] I have verified that test coverage meets or exceeds 95%.  
- [x] I have run the test suite locally and all tests pass.  

---

### **Other information**  
The fix ensures that the test suite passes consistently without failing intermittently due to datetime issues.  

---

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/switchmap-ng/blob/main/CONTRIBUTING.md)?**  
Yes  

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Improved test robustness for Mac Port database operations
	- Enhanced test methods to ensure unique record generation
	- Updated test comments for better clarity and precision

<!-- end of auto-generated comment: release notes by coderabbit.ai -->