### PR TITLE
Add Graphql endpoint unittests (#191)

### DIFF
--- a/tests/switchmap_/server/api/routes/test_graphql.py
+++ b/tests/switchmap_/server/api/routes/test_graphql.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Unittests for the API Graphql routes.
 
-This module tests the functionaliity in the Graphql endpoint.
+This module tests the functionality in the Graphql endpoint.
 """
 
 import json
@@ -155,15 +155,12 @@ class TestGraphqlAPIRoute(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("data", response.json)
-        self.assertIn(
-            new_device.sys_name,
-            list(
-                map(
-                    lambda x: x["node"]["sysName"],
-                    response.json["data"]["devices"]["edges"],
-                )
-            ),
-        )
+
+        sys_names = [
+            res["node"]["sysName"]
+            for res in response.json["data"]["devices"]["edges"]
+        ]
+        self.assertIn(new_device.sys_name, sys_names)
 
     def test_graphql_invalid_query(self) -> None:
         """Test invalid query returns correct error response."""

--- a/tests/switchmap_/server/api/routes/test_graphql.py
+++ b/tests/switchmap_/server/api/routes/test_graphql.py
@@ -1,31 +1,94 @@
 #!/usr/bin/env python3
 """Unittests for the API Graphql routes.
 
-This module tests the functionaliity in the qraphql endpoint.
+This module tests the functionaliity in the Graphql endpoint.
 """
 
 import json
 import os
+import random
 import sys
 import unittest
-from unittest.mock import patch
 
 from flask import Flask
 
-sys.path.append(
-    os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
+EXEC_DIR = os.path.dirname(os.path.realpath(__file__))
+ROOT_DIR = os.path.abspath(
+    os.path.join(
+        os.path.abspath(
+            os.path.join(
+                os.path.abspath(
+                    os.path.join(
+                        os.path.abspath(
+                            os.path.join(
+                                os.path.abspath(os.path.join(EXEC_DIR, os.pardir)),
+                                os.pardir,
+                            )
+                        ),
+                        os.pardir,
+                    )
+                ),
+                os.pardir,
+            )
+        ),
+        os.pardir,
+    )
 )
+_EXPECTED = """\
+{0}switchmap-ng{0}tests{0}switchmap_{0}server{0}api{0}routes""".format(os.sep)
+if EXEC_DIR.endswith(_EXPECTED) is True:
+    # We need to prepend the path in case the repo has been installed
+    # elsewhere on the system using PIP. This could corrupt expected results
+    sys.path.insert(0, ROOT_DIR)
+else:
+    print(
+        """This script is not installed in the "{0}" directory. Please fix.\
+""".format(_EXPECTED)
+    )
+    sys.exit(2)
+
+from tests.testlib_ import setup
+
+CONFIG = setup.config()
+CONFIG.save()
 
 from switchmap.server.api.routes.graphql import API_GRAPHQL
+from switchmap.server.db import models
+from switchmap.server.db.table import IDevice
+from switchmap.server.db.table import device as testimport
+from tests.testlib_ import data, db
 
 
 class TestGraphqlAPIRoute(unittest.TestCase):
     """Test graphql route."""
 
-    def setUp(self) -> None:
-        """Start up resources for test."""
-        super().setUp()
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Start up resources for class."""
+        config = setup.config()
+        config.save()
 
+        models.create_all_tables()
+
+        db.populate()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Cleanup class resources."""
+        from switchmap.server.db import SCOPED_SESSION
+
+        if (
+            SCOPED_SESSION is not None
+        ):  # makes sure no session is active before dropping connection
+            SCOPED_SESSION.remove()
+
+        database = db.Database()
+        database.drop()
+
+        CONFIG.cleanup()
+
+    def setUp(self) -> None:
+        """Start up resources for each test."""
         self.app = Flask(__name__)
         self.app.register_blueprint(API_GRAPHQL)
 
@@ -35,57 +98,69 @@ class TestGraphqlAPIRoute(unittest.TestCase):
         """Test providing no query returns errors."""
         resp = self.client.get("/graphql")
 
-        data: dict = resp.get_json()
-
+        data = resp.json
+        self.assertEqual(resp.status_code, 400)
         self.assertGreater(len(data), 0)
         self.assertIn("errors", data)
         self.assertDictEqual(
             data["errors"][0], {"message": "Must provide query string."}
         )
 
-    @patch("flask.testing.FlaskClient.post")
-    def test_graphql_query(self, mock_post) -> None:
+    def test_graphql_query(self) -> None:
         """Test valid query returns correct response."""
         query = """
-        query GetDevice($id: ID!) {
-          device(id: $id) {
-            id
-            name
-            type
-          }
-        }
-        """
-        result = {
-            "data": {
-                "device": {"id": "device-123", "name": "Router A", "type": "ROUTER"}
+            {
+              devices{
+                edges {
+                  node {
+                    sysName
+                    name
+                    hostname
+                    sysObjectid
+                    sysDescription
+                    sysUptime
+                    enabled
+                    lastPolled
+                  }
+                }
+              }
             }
-        }
-        mock_post.return_value.status_code = 200
-        mock_post.return_value.get_json.return_value = result
+        """
+
+        new_device = IDevice(
+            idx_zone=1,
+            sys_name=data.random_string(),
+            hostname=data.random_string(),
+            name=data.random_string(),
+            sys_description=data.random_string(),
+            sys_objectid=data.random_string(),
+            sys_uptime=random.randint(0, 1000000),
+            last_polled=random.randint(0, 1000000),
+            enabled=1,
+        )
+
+        testimport.insert_row(new_device)
 
         response = self.client.post(
             "/graphql",
-            data=json.dumps({"query": query, "variables": {"id": "device-123"}}),
+            data=json.dumps({"query": query}),
+            headers={"Content-Type": "application/json"},
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn("data", response.get_json())
-        self.assertDictEqual(result, response.get_json())
+        self.assertIn("data", response.json)
+        self.assertIn(
+            new_device.sys_name,
+            list(
+                map(
+                    lambda x: x["node"]["sysName"],
+                    response.json["data"]["devices"]["edges"],
+                )
+            ),
+        )
 
-    @patch("flask.testing.FlaskClient.post")
-    def test_graphql_invalid_query(self, mock_post) -> None:
+    def test_graphql_invalid_query(self) -> None:
         """Test invalid query returns correct error response."""
-        result = {
-            "errors": [
-                {
-                    "message": "Syntax Error: Unexpected Name 'NoneExistentField'",
-                    "locations": [{"line": 2, "column": 3}],
-                }
-            ]
-        }
-        mock_post.return_value.status_code = 400
-        mock_post.return_value.get_json.return_value = result
-
         query = """
         query InvalidQuery {
           NoneExistentField {
@@ -97,11 +172,17 @@ class TestGraphqlAPIRoute(unittest.TestCase):
         response = self.client.post(
             "/graphql",
             data=json.dumps({"query": query}),
+            headers={"Content-Type": "application/json"},
         )
 
         self.assertEqual(response.status_code, 400)
-        self.assertIn("errors", response.get_json())
+        self.assertIn("errors", response.json)
         self.assertEqual(
-            response.get_json()["errors"][0]["message"],
-            "Syntax Error: Unexpected Name 'NoneExistentField'",
+            response.json["errors"][0]["message"],
+            "Cannot query field 'NoneExistentField' on type 'Query'.",
         )
+
+
+if __name__ == "__main__":
+    # Do the unit test
+    unittest.main()

--- a/tests/switchmap_/server/api/routes/test_graphql.py
+++ b/tests/switchmap_/server/api/routes/test_graphql.py
@@ -21,7 +21,9 @@ ROOT_DIR = os.path.abspath(
                     os.path.join(
                         os.path.abspath(
                             os.path.join(
-                                os.path.abspath(os.path.join(EXEC_DIR, os.pardir)),
+                                os.path.abspath(
+                                    os.path.join(EXEC_DIR, os.pardir)
+                                ),
                                 os.pardir,
                             )
                         ),
@@ -35,7 +37,9 @@ ROOT_DIR = os.path.abspath(
     )
 )
 _EXPECTED = """\
-{0}switchmap-ng{0}tests{0}switchmap_{0}server{0}api{0}routes""".format(os.sep)
+{0}switchmap-ng{0}tests{0}switchmap_{0}server{0}api{0}routes""".format(
+    os.sep
+)
 if EXEC_DIR.endswith(_EXPECTED) is True:
     # We need to prepend the path in case the repo has been installed
     # elsewhere on the system using PIP. This could corrupt expected results
@@ -43,7 +47,9 @@ if EXEC_DIR.endswith(_EXPECTED) is True:
 else:
     print(
         """This script is not installed in the "{0}" directory. Please fix.\
-""".format(_EXPECTED)
+""".format(
+            _EXPECTED
+        )
     )
     sys.exit(2)
 

--- a/tests/switchmap_/server/api/routes/test_graphql.py
+++ b/tests/switchmap_/server/api/routes/test_graphql.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Unittests for the API Graphql routes.
+
+This module tests the functionaliity in the qraphql endpoint.
+"""
+
+import json
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+from flask import Flask
+
+sys.path.append(
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
+)
+
+from switchmap.server.api.routes.graphql import API_GRAPHQL
+
+
+class TestGraphqlAPIRoute(unittest.TestCase):
+    """Test graphql route."""
+
+    def setUp(self) -> None:
+        """Start up resources for test."""
+        super().setUp()
+
+        self.app = Flask(__name__)
+        self.app.register_blueprint(API_GRAPHQL)
+
+        self.client = self.app.test_client()
+
+    def test_graphql_no_query(self) -> None:
+        """Test providing no query returns errors."""
+        resp = self.client.get("/graphql")
+
+        data: dict = resp.get_json()
+
+        self.assertGreater(len(data), 0)
+        self.assertIn("errors", data)
+        self.assertDictEqual(
+            data["errors"][0], {"message": "Must provide query string."}
+        )
+
+    @patch("flask.testing.FlaskClient.post")
+    def test_graphql_query(self, mock_post) -> None:
+        """Test valid query returns correct response."""
+        query = """
+        query GetDevice($id: ID!) {
+          device(id: $id) {
+            id
+            name
+            type
+          }
+        }
+        """
+        result = {
+            "data": {
+                "device": {"id": "device-123", "name": "Router A", "type": "ROUTER"}
+            }
+        }
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.get_json.return_value = result
+
+        response = self.client.post(
+            "/graphql",
+            data=json.dumps({"query": query, "variables": {"id": "device-123"}}),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("data", response.get_json())
+        self.assertDictEqual(result, response.get_json())
+
+    @patch("flask.testing.FlaskClient.post")
+    def test_graphql_invalid_query(self, mock_post) -> None:
+        """Test invalid query returns correct error response."""
+        result = {
+            "errors": [
+                {
+                    "message": "Syntax Error: Unexpected Name 'NoneExistentField'",
+                    "locations": [{"line": 2, "column": 3}],
+                }
+            ]
+        }
+        mock_post.return_value.status_code = 400
+        mock_post.return_value.get_json.return_value = result
+
+        query = """
+        query InvalidQuery {
+          NoneExistentField {
+            id
+            name
+          }
+        }
+        """
+        response = self.client.post(
+            "/graphql",
+            data=json.dumps({"query": query}),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("errors", response.get_json())
+        self.assertEqual(
+            response.get_json()["errors"][0]["message"],
+            "Syntax Error: Unexpected Name 'NoneExistentField'",
+        )

--- a/tests/switchmap_/server/api/routes/test_graphql.py
+++ b/tests/switchmap_/server/api/routes/test_graphql.py
@@ -187,5 +187,5 @@ class TestGraphqlAPIRoute(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    # Do the unit test
+    # Run the unit test
     unittest.main()


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Unit tests for the graphql api endpoint

**Issue Number:**

Fixes #191 

**Snapshots/Videos:**

None

**If relevant, did you update the documentation?**

None

**Summary**

This pull request adds tests for the graphql api endpoint. It is a rerun to #300 and #301 to fix issues identified by github action.

**Does this PR introduce a breaking change?**

None

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

None

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/switchmap-ng/blob/main/CONTRIBUTING.md)?**

Yes